### PR TITLE
Remove support for wiring up Duply to Cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ An Ansible role for installing [Duply](http://duply.net/). In addition, this rol
 - `duply_source` - Source path of backups
 - `duply_max_age` - Maximum age for backups (default: `1M` for 1 month)
 - `duply_excludes` - A list of backup exclusions  (default: `[]`)
-- `duply_cron_special_time` - A special time specification nickname (see [here](http://docs.ansible.com/cron_module.html) for details)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,4 +9,3 @@ duply_target_pass: ""
 duply_source: "/var/www/html"
 duply_max_age: "1M"
 duply_excludes: []
-duply_cron_special_time: "daily"

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -7,4 +7,3 @@
       duply_target_user: "<AWS_ACCESS_KEY>"
       duply_target_pass: "<AWS_SECRET_KEY>"
       duply_source: "/home/vagrant"
-      duply_cron_special_time: "hourly"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,9 +17,3 @@
   with_items:
     - conf
     - exclude
-
-- name: Setup a Duply cron job
-  cron: name="duply-{{ duply_profile }}"
-        special_time="{{ duply_cron_special_time }}"
-        job="duply {{ duply_profile }} backup"
-        state=present


### PR DESCRIPTION
Initial Cron support was too presumptuous. Removing it and allowing the role's user to setup their own Cron jobs seems to make more sense.
